### PR TITLE
Camera Follow : bound limits system

### DIFF
--- a/PlaygroundProject/Assets/UnityPlayground/Scripts/Movement/CameraFollow.cs
+++ b/PlaygroundProject/Assets/UnityPlayground/Scripts/Movement/CameraFollow.cs
@@ -8,12 +8,23 @@ public class CameraFollow : MonoBehaviour
 	// This is the object that the camera will follow
 	public Transform target;
 
+    //Bound camera to limits
+    public bool limitBounds = false;
+    public float xMin = 0f;
+    public float xMax = 0f;
+    public float yMin = -5f;
+    public float yMax = 5f;
 
 	private Vector3 lerpedPosition;
 
+    private Camera _camera;
 
-	// FixedUpdate is called every frame, when the physics are calculated
-	void FixedUpdate()
+    private void Awake() {
+        _camera = GetComponent<Camera>();
+    }
+
+    // FixedUpdate is called every frame, when the physics are calculated
+    void FixedUpdate()
 	{
 		if(target != null)
 		{
@@ -32,6 +43,29 @@ public class CameraFollow : MonoBehaviour
 		{
 			// Move the camera in the position found previously
 			transform.position = lerpedPosition;
+
+            // Bounds the camera to the limits (if enabled)
+            if(limitBounds) {
+                Vector3 bottomLeft = _camera.ScreenToWorldPoint(Vector3.zero);
+                Vector3 topRight = _camera.ScreenToWorldPoint(new Vector3(_camera.pixelWidth, _camera.pixelHeight));
+                Vector2 screenSize = new Vector2(topRight.x - bottomLeft.x, topRight.y - bottomLeft.y);
+
+                Vector3 boundPosition = transform.position;
+                if (boundPosition.x > xMax - (screenSize.x / 2f)) {
+                    boundPosition.x = xMax - (screenSize.x / 2f);
+                }
+                if (boundPosition.x < xMin + (screenSize.x / 2f)) {
+                    boundPosition.x = xMin + (screenSize.x / 2f);
+                }
+
+                if (boundPosition.y > yMax - (screenSize.y / 2f)) {
+                    boundPosition.y = yMax - (screenSize.y / 2f);
+                }
+                if (boundPosition.y < yMin + (screenSize.y / 2f)) {
+                    boundPosition.y = yMin + (screenSize.y / 2f);
+                }
+                transform.position = boundPosition;
+            }
 		}
 	}
 }

--- a/PlaygroundProject/Assets/UnityPlayground/_DONT_USE/Scripts/Editor/Movement/CameraFollowInspector.cs
+++ b/PlaygroundProject/Assets/UnityPlayground/_DONT_USE/Scripts/Editor/Movement/CameraFollowInspector.cs
@@ -10,6 +10,8 @@ public class CameraFollowInspector : InspectorBase
 	private string warning = "WARNING: No object is selected, so the Camera won't move.";
 	private string requiresCamera = "This script requires a Camera component to work. Add it to the Camera GameObject.";
 
+    private string undoLimitBoundsMessage = "Change camera follow bounds";
+
 	private GameObject go;
 
 	private void OnEnable()
@@ -31,13 +33,81 @@ public class CameraFollowInspector : InspectorBase
 		}
 		else
 		{
-			//draw normal inspector
-			base.OnInspectorGUI();
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("target"));
 
-			if(!CheckIfAssigned("target", false))
+            if (!CheckIfAssigned("target", false))
 			{
 				EditorGUILayout.HelpBox(warning, MessageType.Warning);
 			}
-		}
+
+            GUILayout.Space(5);
+            GUILayout.Label("Limits", EditorStyles.boldLabel);
+            bool allowLimitBoundsTemp = EditorGUILayout.Toggle("Limit Bounds", serializedObject.FindProperty("limitBounds").boolValue);
+            if (allowLimitBoundsTemp) {
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("xMin"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("xMax"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("yMin"));
+                EditorGUILayout.PropertyField(serializedObject.FindProperty("yMax"));
+            }
+            serializedObject.FindProperty("limitBounds").boolValue = allowLimitBoundsTemp;
+
+            serializedObject.ApplyModifiedProperties();
+        }
 	}
+
+    private void OnSceneGUI() {
+        CameraFollow followScript = target as CameraFollow;
+        if (null == followScript) return;
+
+        Handles.color = Color.yellow;
+        if (followScript.limitBounds) {
+            Vector3[] verts = new Vector3[4];
+            verts[0] = new Vector3(followScript.xMin, followScript.yMin, 0f);
+            verts[1] = new Vector3(followScript.xMax, followScript.yMin, 0f);
+            verts[2] = new Vector3(followScript.xMax, followScript.yMax, 0f);
+            verts[3] = new Vector3(followScript.xMin, followScript.yMax, 0f);
+            Handles.DrawSolidRectangleWithOutline(verts, Color.clear, Color.yellow);
+
+            float handleSize = 0.25f;
+            Vector3 handleSnap = Vector3.one;
+            Quaternion handleRotation = Quaternion.identity;
+            Handles.CapFunction handleCapFunction = Handles.DotHandleCap;
+
+            //Dot bottom left
+            EditorGUI.BeginChangeCheck();
+            Vector3 tmpBottomLeft = Handles.FreeMoveHandle(verts[0], handleRotation, handleSize, handleSnap, handleCapFunction);
+            if (EditorGUI.EndChangeCheck()) {
+                Undo.RecordObject(followScript, undoLimitBoundsMessage);
+                followScript.xMin = tmpBottomLeft.x;
+                followScript.yMin = tmpBottomLeft.y;
+            }
+
+            //Dot bottom right
+            EditorGUI.BeginChangeCheck();
+            Vector3 tmpBottomRight = Handles.FreeMoveHandle(verts[1], handleRotation, handleSize, handleSnap, handleCapFunction);
+            if (EditorGUI.EndChangeCheck()) {
+                Undo.RecordObject(followScript, undoLimitBoundsMessage);
+                followScript.xMax = tmpBottomRight.x;
+                followScript.yMin = tmpBottomRight.y;
+            }
+
+            //Dot top right
+            EditorGUI.BeginChangeCheck();
+            Vector3 tmpTopRight = Handles.FreeMoveHandle(verts[2], handleRotation, handleSize, handleSnap, handleCapFunction);
+            if (EditorGUI.EndChangeCheck()) {
+                Undo.RecordObject(followScript, undoLimitBoundsMessage);
+                followScript.xMax = tmpTopRight.x;
+                followScript.yMax = tmpTopRight.y;
+            }
+
+            //Dot top left
+            EditorGUI.BeginChangeCheck();
+            Vector3 tmpTopLeft = Handles.FreeMoveHandle(verts[3], handleRotation, handleSize, handleSnap, handleCapFunction);
+            if (EditorGUI.EndChangeCheck()) {
+                Undo.RecordObject(followScript, undoLimitBoundsMessage);
+                followScript.xMin = tmpTopLeft.x;
+                followScript.yMax = tmpTopLeft.y;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Hey!

Some of my students asked for a way to bound the camera follow scripts with limits.

I've created a tool which generates a rectangle to set camera bounds for the current level. It could useful when scene contains begin/end spots. It should respect camera aspect ratio.

Here's an example of how it works (**playmode is active**) :

![camerafollowbounds](https://user-images.githubusercontent.com/3427268/41819692-062c428c-77c5-11e8-9a43-3c2d5d0584c3.gif)

If you think it's not too complicated for your students, you can integrate it into the main project. And I can improve it if it's not intuitive enough.

Cheers! :)

